### PR TITLE
Expose getSpec

### DIFF
--- a/link-to-inbox.js
+++ b/link-to-inbox.js
@@ -120,6 +120,7 @@
 	// can return a function as the exported value.
 	return {
 		createLink: createLink,
-		getHref: getHref
+		getHref: getHref,
+		getSpec: getSpec
 	}
 }));


### PR DESCRIPTION
I'm using the `getSpec` part of the package for https://github.com/doug-wade/react-link-to-inbox, so this pr just exposes it as part of the public api